### PR TITLE
fix(ios): fix `connectedScenes` is called in background thread

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -903,20 +903,22 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         #if !os(tvOS)
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              !ProcessInfo.processInfo.isiOSAppOnMac else {
-            return
-        }
-
-        Task {
-            do {
-                try await AppStore.showManageSubscriptions(in: scene)
-            } catch {
-                print("Error:(error)")
+        DispatchQueue.main.async {
+            guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  !ProcessInfo.processInfo.isiOSAppOnMac else {
+                return
             }
-        }
 
-        resolve(nil)
+            Task {
+                do {
+                    try await AppStore.showManageSubscriptions(in: scene)
+                } catch {
+                    print("Error:(error)")
+                }
+            }
+
+            resolve(nil)
+        }
         #else
         reject(IapErrors.E_USER_CANCELLED.rawValue, "This method is not available on tvOS", nil)
         #endif


### PR DESCRIPTION
Xcode Main Thread Checker reported `UIApplication.shared.connectedScenes` is called on a background thread when use `showManageSubscriptions` API. We should call the UI API in the main thread.

Full log:

```
Main Thread Checker: UI API called on a background thread: -[UIApplication connectedScenes]
PID: 86915, TID: 487323, Thread name: (none), Queue name: com.facebook.react.RNIapIosSk2Queue, QoS: 0
Backtrace:
4   GcoresMobile                        0x0000000102873262 $s5RNIap0A11IosSk2iOS15C23showManageSubscriptions_6rejectyyypSgc_ySSSg_AGs5Error_pSgtctF + 210
5   GcoresMobile                        0x0000000102877338 $s5RNIap0A11IosSk2iOS15CAA11Sk2DelegateA2aDP23showManageSubscriptions_6rejectyyypSgc_ySSSg_AIs5Error_pSgtctFTW + 24
6   GcoresMobile                        0x00000001028606cd $s5RNIap0A6IosSk2C23showManageSubscriptions_6rejectyyypSgc_ySSSg_AGs5Error_pSgtctF + 157
7   GcoresMobile                        0x0000000102860792 $s5RNIap0A6IosSk2C23showManageSubscriptions_6rejectyyypSgc_ySSSg_AGs5Error_pSgtctFTo + 162
8   CoreFoundation                      0x0000000110dd409c __invoking___ + 140
9   CoreFoundation                      0x0000000110dd1406 -[NSInvocation invoke] + 305
10  CoreFoundation                      0x0000000110dd16a5 -[NSInvocation invokeWithTarget:] + 70
11  GcoresMobile                        0x0000000102ad3e12 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2498
12  GcoresMobile                        0x0000000102ad88eb _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicEiN12_GLOBAL__N_117SchedulingContextE + 2043
13  GcoresMobile                        0x0000000102ad7f35 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 133
14  GcoresMobile                        0x0000000102ad7ea9 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 25
15  libdispatch.dylib                   0x000000011ab4f54f _dispatch_call_block_and_release + 12
16  libdispatch.dylib                   0x000000011ab507ec _dispatch_client_callout + 8
17  libdispatch.dylib                   0x000000011ab586ae _dispatch_lane_serial_drain + 1115
18  libdispatch.dylib                   0x000000011ab594a6 _dispatch_lane_invoke + 428
19  libdispatch.dylib                   0x000000011ab67982 _dispatch_workloop_worker_thread + 962
20  libsystem_pthread.dylib             0x000000011d4e0ce3 _pthread_wqthread + 326
21  libsystem_pthread.dylib             0x000000011d4dfc67 start_wqthread + 15
```