### PR TITLE
feat: include JWS representation of purchase verification when using StoreKit 2

### DIFF
--- a/ios/IapSerializationUtils.swift
+++ b/ios/IapSerializationUtils.swift
@@ -176,6 +176,12 @@ func serialize(_ t: Transaction) -> [String: Any?] {
     ]
 }
 @available(iOS 15.0, tvOS 15.0, *)
+func serialize(_ t: Transaction, _ v: VerificationResult<Transaction>) -> [String: Any?] {
+    var transaction = serialize(t)
+    transaction.updateValue(v.jwsRepresentation, forKey: "verificationResult")
+    return transaction
+}
+@available(iOS 15.0, tvOS 15.0, *)
 func serialize(_ ot: Transaction.OfferType?) -> String? {
     guard let ot = ot else {return nil}
     switch ot {

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -474,8 +474,8 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                     // await self.updateCustomerProductStatus()
 
                     if self.hasListeners {
-                        self.sendEvent?("purchase-updated", serialize(transaction))
-                        self.sendEvent?("iap-transaction-updated", ["transaction": serialize(transaction)])
+                        self.sendEvent?("purchase-updated", serialize(transaction, result))
+                        self.sendEvent?("iap-transaction-updated", ["transaction": serialize(transaction, result)])
                     }
                     // Always finish a transaction.
                     // await transaction.finish()
@@ -690,8 +690,8 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                             resolve(nil)
                         } else {
                             self.addTransaction(transaction)
-                            self.sendEvent?("purchase-updated", serialize(transaction))
-                            resolve(serialize(transaction))
+                            self.sendEvent?("purchase-updated", serialize(transaction, verification))
+                            resolve(serialize(transaction, verification))
                         }
                         return
 
@@ -800,7 +800,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                     do {
                         // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
                         let transaction = try checkVerified(result)
-                        resolve(serialize(transaction))
+                        resolve(serialize(transaction, result))
                     } catch StoreError.failedVerification {
                         reject(IapErrors.E_UNKNOWN.rawValue, "Failed to verify transaction for sku \(sku)", StoreError.failedVerification)
                     } catch {
@@ -827,7 +827,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                     do {
                         // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
                         let transaction = try checkVerified(result)
-                        resolve(serialize(transaction))
+                        resolve(serialize(transaction, result))
                     } catch StoreError.failedVerification {
                         reject(IapErrors.E_UNKNOWN.rawValue, "Failed to verify transaction for sku \(sku)", StoreError.failedVerification)
                     } catch {

--- a/src/types/appleSk2.ts
+++ b/src/types/appleSk2.ts
@@ -60,7 +60,7 @@ export const productSk2Map = ({
     type: 'iap',
     price: String(price),
     localizedPrice: displayPrice,
-    currency: '', // Not avaiable on new API, use localizedPrice instead
+    currency: '', // Not available on new API, use localizedPrice instead
   };
   return prod;
 };
@@ -81,7 +81,7 @@ export const subscriptionSk2Map = ({
     type: 'subs',
     price: String(price),
     localizedPrice: displayPrice,
-    currency: '', // Not avaiable on new API, use localizedPrice instead
+    currency: '', // Not available on new API, use localizedPrice instead
     subscriptionPeriodNumberIOS: `${subscription?.subscriptionPeriod?.value}`,
     subscriptionPeriodUnitIOS:
       subscription?.subscriptionPeriod?.unit.toUpperCase() as SubscriptionIosPeriod,
@@ -114,6 +114,7 @@ export type TransactionSk2 = {
   signedDate: number;
   subscriptionGroupID: number;
   webOrderLineItemID: number;
+  verificationResult?: string;
 };
 
 export type TransactionError = PurchaseError;
@@ -144,16 +145,18 @@ export const transactionSk2ToPurchaseMap = ({
   purchaseDate,
   purchasedQuantity,
   originalID,
+  verificationResult,
 }: TransactionSk2): Purchase => {
   const purchase: Purchase = {
     productId: productID,
     transactionId: String(id),
     transactionDate: purchaseDate, //??
     transactionReceipt: '', // Not available
-    purchaseToken: '', //Not avaiable
+    purchaseToken: '', //Not available
     quantityIOS: purchasedQuantity,
     originalTransactionDateIOS: originalPurchaseDate,
     originalTransactionIdentifierIOS: originalID,
+    verificationResultIOS: verificationResult ?? '',
   };
   return purchase;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,7 @@ export interface ProductPurchase {
   quantityIOS?: number;
   originalTransactionDateIOS?: number;
   originalTransactionIdentifierIOS?: string;
+  verificationResultIOS?: string;
   //Android
   productIds?: string[];
   dataAndroid?: string;
@@ -98,6 +99,7 @@ export interface SubscriptionPurchase extends ProductPurchase {
   autoRenewingAndroid?: boolean;
   originalTransactionDateIOS?: number;
   originalTransactionIdentifierIOS?: string;
+  verificationResultIOS?: string;
 }
 
 export type Purchase = ProductPurchase | SubscriptionPurchase;


### PR DESCRIPTION
This PR adds the JWS representation of the App Store verification when using StoreKit 2 (iOS/tvOS) to the purchase response as well as `purchase-updated` and `iap-transaction-updated` events.