### PR TITLE
docs: purchases.md use object instead of params in requestSubscription call

### DIFF
--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -116,10 +116,10 @@ class App extends Component {
 
   subscribe = async (sku: string, offerToken: string?) => {
     try {
-      await requestSubscription(
-        {sku},
+      await requestSubscription({
+        sku,
         ...(offerToken && {subscriptionOffers: [{sku, offerToken}]}),
-      );
+      });
     } catch (err) {
       console.warn(err.code, err.message);
     }


### PR DESCRIPTION
The example shown in purchases.md has the wrong interface use for the function `requestSubscription`

In the docs example is shown as
```typescript
      await requestSubscription(
        {sku},
        ...(offerToken && {subscriptionOffers: [{sku, offerToken}]}),
      );
```

While the interface to the function requires an object of the type `RequestSubscription` and not 2 args