### PR TITLE
fix: added missing iOS appAccountToken on ProductPurchase TS interface

### DIFF
--- a/src/types/appleSk2.ts
+++ b/src/types/appleSk2.ts
@@ -146,6 +146,7 @@ export const transactionSk2ToPurchaseMap = ({
   purchasedQuantity,
   originalID,
   verificationResult,
+  appAccountToken
 }: TransactionSk2): Purchase => {
   const purchase: Purchase = {
     productId: productID,
@@ -157,6 +158,7 @@ export const transactionSk2ToPurchaseMap = ({
     originalTransactionDateIOS: originalPurchaseDate,
     originalTransactionIdentifierIOS: originalID,
     verificationResultIOS: verificationResult ?? '',
+    appAccountToken: appAccountToken ?? '',
   };
   return purchase;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export interface ProductPurchase {
   originalTransactionDateIOS?: number;
   originalTransactionIdentifierIOS?: string;
   verificationResultIOS?: string;
+  appAccountToken?: string;
   //Android
   productIds?: string[];
   dataAndroid?: string;


### PR DESCRIPTION
Fixing issue #2434 