### PR TITLE
fix: update TS definitions for purchase methods (#2509)

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -576,7 +576,7 @@ const App = () => {
 
 export const requestPurchase = (
   request: RequestPurchase,
-): Promise<ProductPurchase | void> =>
+): Promise<ProductPurchase | ProductPurchase[] | void> =>
   (
     Platform.select({
       ios: async () => {
@@ -732,7 +732,7 @@ const App = () => {
  */
 export const requestSubscription = (
   request: RequestSubscription,
-): Promise<SubscriptionPurchase | null | void> =>
+): Promise<SubscriptionPurchase | SubscriptionPurchase[] | null | void> =>
   (
     Platform.select({
       ios: async () => {


### PR DESCRIPTION
This PR fixed TS definitions for requestPurchase and requestSubscription functions.
Ensured that the return values align with the expected types.

ref: https://github.com/dooboolab-community/react-native-iap/issues/2426