### PR TITLE
Enable support for Android 14

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@ RNIap_buildToolsVersion=30.0.2
 RNIap_ndkversion=21.4.7075529
 RNIap_playServicesVersion=18.1.0
 RNIap_amazonSdkVersion=3.0.3
-RNIap_playBillingSdkVersion=5.1.0
+RNIap_playBillingSdkVersion=5.2.1
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Recently, a warning in Google Play Console appears due to the Google Play Billing Version not being updated enough:

<img width="680" alt="Screenshot 2023-08-07 at 10 15 10" src="https://github.com/dooboolab-community/react-native-iap/assets/11445806/ea446dea-fbaf-4554-84ba-454e5f36b139">

In order to support Android 14 while not introducing breaking changes in the library, I've updated the minor version of the SDK to `5.2.1`

<img width="931" alt="Screenshot 2023-08-07 at 10 22 26" src="https://github.com/dooboolab-community/react-native-iap/assets/11445806/6a414058-02d5-45c9-ab70-6e23680df883">

Further reading:
https://android-developers.googleblog.com/2023/06/changes-to-google-play-developer-api-june-2023.html
https://developer.android.google.cn/google/play/billing/release-notes#5-2-1
