### PR TITLE
Update Kotlin Version In Docs  

### DIFF
--- a/docs/docs/get-started.md
+++ b/docs/docs/get-started.md
@@ -57,7 +57,7 @@ buildscript {
 +    androidXAnnotation = "1.1.0"
 +    androidXBrowser = "1.0.0"
 +    minSdkVersion = 24
-+    kotlinVersion = "1.6.0"
++    kotlinVersion = "1.8.0"
   }
 }
 


### PR DESCRIPTION
#2535
After version `12.10.7` build will fail with
```
INF/java.com.google.android.libraries.play.billing.public.ktbilling_granule.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0.
```
Downgrading to `12.10.5` works with 1.6.0