### PR TITLE
Fix/populate initial prices

### DIFF
--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -2,7 +2,7 @@ import {EmitterSubscription, NativeEventEmitter} from 'react-native';
 
 import {TransactionEvent, transactionSk2ToPurchaseMap} from './types/appleSk2';
 import {isIosStorekit2} from './iap';
-import {getIosModule, getNativeModule, isIos} from './internal';
+import { getAndroidModule, getIosModule, getNativeModule, isAndroid, isIos } from './internal';
 import type {PurchaseError} from './purchaseError';
 import type {Purchase} from './types';
 
@@ -51,6 +51,10 @@ export const purchaseUpdatedListener = (
     'purchase-updated',
     proxyListener,
   );
+
+  if (isAndroid) {
+    getAndroidModule().startListening();
+  }
 
   return emitterSubscription;
 };

--- a/src/internal/fillProductsWithAdditionalData.ts
+++ b/src/internal/fillProductsWithAdditionalData.ts
@@ -35,7 +35,10 @@ export const fillProductsWithAdditionalData = async <T extends ProductCommon>(
     // Add currency to items
     items.forEach((item) => {
       if (currency) {
+        const { originalPrice } = item;
         item.currency = currency;
+        item.price = originalPrice;
+        item.localizedPrice = originalPrice;
       }
     });
   }

--- a/src/internal/fillProductsWithAdditionalData.ts
+++ b/src/internal/fillProductsWithAdditionalData.ts
@@ -35,10 +35,10 @@ export const fillProductsWithAdditionalData = async <T extends ProductCommon>(
     // Add currency to items
     items.forEach((item) => {
       if (currency) {
-        const { originalPrice } = item;
+        const {originalPrice} = item;
         item.currency = currency;
-        item.price = originalPrice;
-        item.localizedPrice = originalPrice;
+        item.price = originalPrice ?? '0.0';
+        item.localizedPrice = originalPrice ?? '0.0';
       }
     });
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,7 +55,7 @@ export interface ProductCommon {
   price: string;
   currency: string;
   localizedPrice: string;
-  originalPrice: string;
+  originalPrice?: string;
   countryCode?: string;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,7 @@ export interface ProductCommon {
   price: string;
   currency: string;
   localizedPrice: string;
+  originalPrice: string;
   countryCode?: string;
 }
 


### PR DESCRIPTION
This pull request addresses two  issues:

**Amazon pricing**
When dealing with Amazon pricing, 'localizedPrice' consistently defaults to 0.0. To rectify this, we've leveraged the 'original price' as the source value for 'localizedPrice.' The primary objective of this patch is to seamlessly populate both 'localizedPrice' and 'price' with values derived from 'originalPrice.'

**purchaseUpdatedListener notifications**
During our investigation, we encountered a similar [issue](https://github.com/dooboolab-community/react-native-iap/issues/2487) where notifications weren't being received within the purchaseUpdatedListener. Our solution involved the reintroduction of the startListening method."