### PR TITLE
fix: correct gradle import instructions in get-started.mdx

### DIFF
--- a/docs/docs/get-started.mdx
+++ b/docs/docs/get-started.mdx
@@ -65,11 +65,10 @@ buildscript {
 +    minSdkVersion = 24
 +    kotlinVersion = "1.8.0"
   }
-}
-
-dependencies {
-  ...
-+ classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  dependencies {
+    ...
++   classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  }
 }
 ```
 


### PR DESCRIPTION
While integrating this on Android, I found that the suggested gradle import changes weren't correct on the [Get Started page](https://react-native-iap.dooboolab.com/docs/get-started#with-androidx).

I have made the correction in this PR.