### PR TITLE
docs: improve documentation 17.11.2023

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,46 +10,40 @@ To get started with the project, run `yarn` in the root directory to install the
 yarn
 ```
 
+### Example app
+
 > While it's possible to use [`npm`](https://github.com/npm/cli), the tooling is built around [`yarn`](https://classic.yarnpkg.com/), so you'll have an easier time if you use `yarn` for development.
 
 While developing, you can run the [example app](/IapExample/) to test your changes. Any changes you make in your library's JavaScript code will be reflected in the example app without a rebuild. If you change any native code, then you'll need to rebuild the example app.
 
+```bash
+cd IapExample
+yarn #install dependencies
+```
+
 To start the packager:
 
 ```bash
-yarn example start
+yarn  start
 ```
 
 To run the example app on Android:
 
 ```bash
-yarn example android
+yarn android:play
+```
+or
+```bash
+yarn android:amazon
 ```
 
 To run the example app on iOS:
 
 ```bash
-yarn example ios
+yarn ios
 ```
 
-Make sure your code passes TypeScript and ESLint. Run the following to verify:
-
-```bash
-yarn typescript
-yarn lint
-```
-
-To fix formatting errors, run the following:
-
-```bash
-yarn lint --fix
-```
-
-Remember to add tests for your change if possible. Run the unit tests by:
-
-```bash
-yarn test
-```
+### Editing native code
 
 To edit the Objective-C files, open `IapExample/ios/IapExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > RNIap`.
 
@@ -76,6 +70,31 @@ We use [TypeScript](https://www.typescriptlang.org/) for type checking, [ESLint]
 
 Our pre-commit hooks verify that the linter and tests pass when committing.
 
+In root directory. Make sure your code passes TypeScript and ESLint. Run the following to verify:
+
+```bash
+yarn lint
+```
+
+To fix formatting errors, run the following:
+
+```bash
+yarn lint --fix
+```
+
+To fix formatting errors in `swift` files:
+- prerequisity: on your Mac install [SwiftLint](https://github.com/realm/SwiftLint)
+
+```bash
+yarn lint:swift
+```
+
+Remember to add tests for your change if possible. Run the unit tests by:
+
+```bash
+yarn test
+```
+
 ### Publishing to npm
 
 We use [release-it](https://github.com/release-it/release-it) to make it easier to publish new versions. It handles common tasks like bumping version based on semver, creating tags and releases etc.
@@ -88,15 +107,14 @@ yarn release
 
 ### Scripts
 
-The `package.json` file contains various scripts for common tasks:
+The [package.json](package.json) file contains various scripts for common tasks:
 
 - `yarn bootstrap`: setup project by installing all dependencies and pods.
 - `yarn typescript`: type-check files with TypeScript.
 - `yarn lint`: lint files with ESLint.
 - `yarn test`: run unit tests with Jest.
-- `yarn example start`: start the Metro server for the example app.
-- `yarn example android`: run the example app on Android.
-- `yarn example ios`: run the example app on iOS.
+
+The [IapExample/package.json](IapExample/package.json) file contains various scripts for common tasks with example app:
 
 ### Sending a pull request
 

--- a/IapExample/README.md
+++ b/IapExample/README.md
@@ -1,5 +1,7 @@
 # Example app
 
+⚠️warn: iOS example currently not working, needs to be updated (ruby, pods, etc)
+
 ## Installation
 
 ```sh
@@ -9,9 +11,7 @@ yarn
 For iOS, do the following:
 
 ```sh
-cd ios
-pod install
-cd -
+yarn pods
 ```
 
 ## Running
@@ -59,9 +59,3 @@ To be able to get products/subscriptions from the App Store or Play Store you wi
    - Product ID: com.cooni.point1000 (can be the value defined in utils/constants.ts)
 9. Go back to the app, login with your account when the AppStore shows you the prompt
 10. Voilà!
-
-## Advanced usage
-
-If you want more advanced one please refer to [dooboolab.com/sponsor.tsx](https://github.com/hyochan/dooboolab.com/blob/main/src/components/pages/Sponsor.tsx)
-
-In order to get products and subscriptions.

--- a/IapExample/package.json
+++ b/IapExample/package.json
@@ -16,7 +16,7 @@
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",
     "lodash": "4.17.21",
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "2.9.0",
     "react-native-safe-area-context": "4.5.0",

--- a/IapExample/package.json
+++ b/IapExample/package.json
@@ -16,7 +16,7 @@
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",
     "lodash": "4.17.21",
-    "react": "18.2.0",
+    "react": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "2.9.0",
     "react-native-safe-area-context": "4.5.0",
@@ -32,7 +32,7 @@
     "babel-plugin-module-resolver": "5.0.0",
     "jest": "^29.0.0",
     "metro-react-native-babel-preset": "^0.76.0",
-    "react-test-renderer": "18.2.0"
+    "react-test-renderer": "18.0.0"
   },
   "resolutions": {
     "@types/react": "17.0.53",

--- a/IapExample/yarn.lock
+++ b/IapExample/yarn.lock
@@ -6928,7 +6928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.2.0":
+"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
@@ -7002,12 +7002,12 @@ __metadata:
     jest: ^29.0.0
     lodash: 4.17.21
     metro-react-native-babel-preset: ^0.76.0
-    react: 18.2.0
+    react: 18.0.0
     react-native: 0.69.1
     react-native-gesture-handler: 2.9.0
     react-native-safe-area-context: 4.5.0
     react-native-screens: 3.20.0
-    react-test-renderer: 18.2.0
+    react-test-renderer: 18.0.0
   languageName: unknown
   linkType: soft
 
@@ -7098,7 +7098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-shallow-renderer@npm:^16.15.0":
+"react-shallow-renderer@npm:^16.13.1":
   version: 16.15.0
   resolution: "react-shallow-renderer@npm:16.15.0"
   dependencies:
@@ -7110,25 +7110,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-test-renderer@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react-test-renderer@npm:18.2.0"
+"react-test-renderer@npm:18.0.0":
+  version: 18.0.0
+  resolution: "react-test-renderer@npm:18.0.0"
   dependencies:
-    react-is: ^18.2.0
-    react-shallow-renderer: ^16.15.0
-    scheduler: ^0.23.0
+    react-is: ^18.0.0
+    react-shallow-renderer: ^16.13.1
+    scheduler: ^0.21.0
   peerDependencies:
-    react: ^18.2.0
-  checksum: 6b6980ced93fa2b72662d5e4ab3b4896833586940047ce52ca9aca801e5432adf05fcbe28289b0af3ce6a2a7c590974e25dcc8aa43d0de658bfe8bbcd686f958
+    react: ^18.0.0
+  checksum: c0e5250fa2e4c3650e247b986c262631bec68f18c06817269ab7a4e2cffa5a152bb58ce0fe4182ffa8c333e6c2a8d763ac92e0928e5f6914a7aa188c2de1943a
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:18.0.0":
+  version: 18.0.0
+  resolution: "react@npm:18.0.0"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
+  checksum: 293020b96536b3c7113ee57ca5c990a3f25649d1751b1c7a3aabd16dff0691fe9f1eed1206616d0906d05933536052037340a0c8d0941ff870b0eb469a2f975b
   languageName: node
   linkType: hard
 
@@ -7449,15 +7449,6 @@ __metadata:
   dependencies:
     loose-envify: ^1.1.0
   checksum: 4f8285076041ed2c81acdd1faa987f1655fdbd30554bc667c1ea64743fc74fb3a04ca7d27454b3d678735df5a230137a3b84756061b43dc5796e80701b66d124
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
-  dependencies:
-    loose-envify: ^1.1.0
-  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 

--- a/IapExample/yarn.lock
+++ b/IapExample/yarn.lock
@@ -7002,7 +7002,7 @@ __metadata:
     jest: ^29.0.0
     lodash: 4.17.21
     metro-react-native-babel-preset: ^0.76.0
-    react: 17.0.2
+    react: 18.2.0
     react-native: 0.69.1
     react-native-gesture-handler: 2.9.0
     react-native-safe-area-context: 4.5.0
@@ -7123,13 +7123,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## docs fixes
- improve setup of project
- remove not working scripts and urls

- I managed to get Android example app to work, but unfortunately not the iOS, see notes bellow:

## update `IAPExample` React to `18.2.0`
    
 - because of  `TypeError: undefined is not an object (evaluating 'ReactCurrentActQueue$1.isBatchingLegacy')`
 - see here: https://github.com/facebook/react-native/issues/34079


## iOS exampke currently not buildable because of:
- because of obsolete pods:
 ```
  $ yarn pods
rbenv: pod: command not found

The `pod' command exists in these Ruby versions:
  2.7.4
```
- see here: https://github.com/facebook/react-native/issues/38921

fixed but then build failed
```
The following build commands failed:
	CompileC /Users/babu/Library/Developer/Xcode/DerivedData/IapExample-ddzasbbwninhdjgvtldlfwsnfkwf/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/RCT-Folly.build/Objects-normal/arm64/json.o /Users/babu/work/powerful-medical/dev/react-native-iap/IapExample/ios/Pods/RCT-Folly/folly/json.cpp normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'RCT-Folly' from project 'Pods')
(1 failure)
``` 

-> this needs more time and investigation, and the question is, is it worth the time? - anyway added warning for anybody trying to build it regarding this README