### PR TITLE
feat: add renewal info for Storekit 2

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -277,10 +277,6 @@ class RNIapIosSk2: RCTEventEmitter, Sk2Delegate {
         delegate.stopObserving()
     }
 
-    override func addListener(_ eventName: String?) {
-        super.addListener(eventName)
-    }
-    
     /**
      "iap-transaction-updated" is unique to Sk2.
      "iap-promoted-product" is only avaiable on Sk1

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -280,7 +280,7 @@ class RNIapIosSk2: RCTEventEmitter, Sk2Delegate {
     override func addListener(_ eventName: String?) {
         super.addListener(eventName)
     }
-
+    
     /**
      "iap-transaction-updated" is unique to Sk2.
      "iap-promoted-product" is only avaiable on Sk1

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,11 @@ export enum ProductType {
   iap = 'iap',
 }
 
+export enum TransactionReason {
+  PURCHASE = 'PURCHASE',
+  RENEWAL = 'RENEWAL',
+}
+
 export interface ProductCommon {
   type: 'subs' | 'sub' | 'inapp' | 'iap';
   productId: string; //iOS
@@ -102,6 +107,7 @@ export interface SubscriptionPurchase extends ProductPurchase {
   originalTransactionDateIOS?: number;
   originalTransactionIdentifierIOS?: string;
   verificationResultIOS?: string;
+  transactionReasonIOS?: TransactionReason | string;
 }
 
 export type Purchase = ProductPurchase | SubscriptionPurchase;


### PR DESCRIPTION
- add renewal info (uncomment and serialize)
- change debugSerialize to serialize - there is info in this property useful for production not only for development
- added transactionReasonIOS enum (to distinguish between type of renewing transactions of purchase events)

see also: [JWSTransactionDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload)