### PR TITLE
feat: add visionOS support

### DIFF
--- a/.github/workflows/ci-example-ios.yml
+++ b/.github/workflows/ci-example-ios.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   build_ios_example:
     runs-on: macos-14
+    env:
+      NO_FLIPPER: 1
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-example-ios.yml
+++ b/.github/workflows/ci-example-ios.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build_ios_example:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout repository
@@ -47,6 +47,9 @@ jobs:
           working-directory: IapExample
           bundler-cache: true
           ruby-version: '2.7'
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
 
       - name: SwiftLint
         run: swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml

--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" , :tvos => "10.0"}
+  s.platforms    = { :ios => "10.0" , :tvos => "10.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/dooboolab-community/react-native-iap.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/*.{h,m,mm,swift}"

--- a/ios/IapSerializationUtils.swift
+++ b/ios/IapSerializationUtils.swift
@@ -165,10 +165,12 @@ func serialize(_ t: Transaction) -> [String: Any?] {
     if #available(iOS 16.0, tvOS 16.0, *) {
         environment = t.environment.rawValue
     } else {
+        #if !os(visionOS)
         let env = t.environmentStringRepresentation
         if ["Production", "Sandbox", "Xcode"].contains(env) {
             environment = env
         }
+        #endif
     }
 
     return ["appAccountToken": t.appAccountToken?.uuidString,

--- a/ios/IapUtils.swift
+++ b/ios/IapUtils.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import StoreKit
+import React
 
 public func debugMessage(_ object: Any...) {
     #if DEBUG
@@ -30,8 +31,10 @@ func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
 }
 
 @available(iOS 15.0, *)
-func currentWindow() -> UIWindow? {
-    return UIApplication.shared.connectedScenes
-        .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-        .last { $0.isKeyWindow }
+func currentWindow() async -> UIWindow? {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.main.async {
+            continuation.resume(returning: RCTKeyWindow())
+        }
+    }
 }

--- a/ios/IapUtils.swift
+++ b/ios/IapUtils.swift
@@ -28,3 +28,10 @@ func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
         return safe
     }
 }
+
+@available(iOS 15.0, *)
+func currentWindow() -> UIWindow? {
+    return UIApplication.shared.connectedScenes
+        .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+        .last { $0.isKeyWindow }
+}

--- a/ios/RNIapIosSk2.m
+++ b/ios/RNIapIosSk2.m
@@ -3,14 +3,11 @@
 #import <React/RCTBridgeModule.h>
 #ifdef __IPHONE_15_0
 
-// From: https://stackoverflow.com/a/5337804/570612
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-
 
 @interface RCT_EXTERN_MODULE (RNIapIosSk2, NSObject)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isAvailable){
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"15.0")) {
+    if (@available(iOS 15.0, *)) {
         return [NSNumber numberWithInt:1];
     }else{
         return [NSNumber numberWithInt:0];

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -712,7 +712,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                     debugMessage("Purchase Started")
 
                     guard let windowScene = await currentWindow()?.windowScene else {
-                        reject(IapErrors.E_USER_CANCELLED.rawValue, "Could not find window scene", nil)
+                        reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Could not find window scene", nil)
                         return
                     }
 
@@ -961,22 +961,20 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         #if !os(tvOS)
-        DispatchQueue.main.async {
-            guard let scene = currentWindow()?.windowScene as? UIWindowScene,
+        Task {
+            guard let scene = await currentWindow()?.windowScene as? UIWindowScene,
                   !ProcessInfo.processInfo.isiOSAppOnMac else {
                 return
             }
 
-            Task {
-                do {
-                    try await AppStore.showManageSubscriptions(in: scene)
-                } catch {
-                    print("Error:(error)")
-                }
+            do {
+                try await AppStore.showManageSubscriptions(in: scene)
+            } catch {
+                print("Error:(error)")
             }
-
-            resolve(nil)
         }
+
+        resolve(nil)
         #else
         reject(IapErrors.E_USER_CANCELLED.rawValue, "This method is not available on tvOS", nil)
         #endif
@@ -1013,9 +1011,8 @@ class RNIapIosSk2iOS15: Sk2Delegate {
             }
         }
 
-        let window = currentWindow()
-
         Task {
+            let window = await currentWindow()
             if let windowScene = await window?.windowScene {
                 if let product = await productStore.getProduct(productID: sku) {
                     if let result = await product.latestTransaction {


### PR DESCRIPTION
This PR adds visionOS support. 

I've refactored some parts of the code to take the currently presented scene by wrapping built-in utility `RCTKeyWindow()` to work in async scenarios.  

## Testing

1. `npx @callstack/react-native-visionos init App`
2. Add react-native-iap
3. Check out if it works

## Demo


https://github.com/dooboolab-community/react-native-iap/assets/52801365/c2391f3a-c8b9-4fd8-acba-e2871c7aaae7


