### PR TITLE
feat: Added export finishTransaction() from StoreKit2.

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -917,6 +917,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                 try await AppStore.sync()
                 resolve(nil)
             } catch {
+                reject(IapErrors.E_SYNC_ERROR.rawValue, "Error synchronizing with the AppStore", error)
                 if "\(error)" == "userCancelled" {
                     reject( IapErrors.E_USER_CANCELLED.rawValue, "User cancelled synchronizing with the AppStore", error)
                 } else {

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -917,7 +917,6 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                 try await AppStore.sync()
                 resolve(nil)
             } catch {
-                reject(IapErrors.E_SYNC_ERROR.rawValue, "Error synchronizing with the AppStore", error)
                 if "\(error)" == "userCancelled" {
                     reject( IapErrors.E_USER_CANCELLED.rawValue, "User cancelled synchronizing with the AppStore", error)
                 } else {

--- a/src/modules/iosSk2.ts
+++ b/src/modules/iosSk2.ts
@@ -102,3 +102,9 @@ export const beginRefundRequest = (sku: string): Promise<RefundRequestStatus> =>
  */
 export const showManageSubscriptions = (): Promise<null> =>
   RNIapIosSk2.showManageSubscriptions();
+
+/**
+ *
+ */
+export const finishTransaction = (transactionIdentifier: string): Promise<Boolean> =>
+  RNIapIosSk2.finishTransaction(transactionIdentifier);


### PR DESCRIPTION
Added a previously missing exported function that allows manual completion of transactions in **StoreKit2**.

Function has already been described in the interface of the **IosModulePropsSk2** in the codebase but lacked accessible invocation.

The function is crucial and must be used to manually complete transactions in in-app purchases using **StoreKit2**. 