### PR TITLE
fix: avoid app crash due to multiple reject invocation

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -917,7 +917,6 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                 try await AppStore.sync()
                 resolve(nil)
             } catch {
-                reject(IapErrors.E_SYNC_ERROR.rawValue, "Error synchronizing with the AppStore", error)
                 if "\(error)" == "userCancelled" {
                     reject( IapErrors.E_USER_CANCELLED.rawValue, "User cancelled synchronizing with the AppStore", error)
                 } else {


### PR DESCRIPTION
Probably, someone forgot to delete the old **Reject** when adding the condition to the code. This leads to an error and crash of the application in the development environment. 

**Steps To Reproduce**:
The error occurs when the user has canceled iOS system prompt for Sync with App Store using StoreKit2.

**Error Message:**
The error says: 'Illegal callback invocation from native module. This callback type only permits a single invocation from native code.'

**Solution**:
Delete redundant reject.