### PR TITLE
Update hooks.md documentation

### DIFF
--- a/docs/docs/api-reference/hooks.md
+++ b/docs/docs/api-reference/hooks.md
@@ -62,7 +62,7 @@ const App = () => {
     <>
       <Button
         title="Get the products"
-        onPress={getProducts(['com.example.consumable'])}
+        onPress={getProducts({ skus: ['product.id'] })}
       />
 
       {products.map((product) => (


### PR DESCRIPTION
The documentation of getProducts hook was outdated.

If you agree, I'd also add more comprehensive documentation when it comes to handling errors. I was getting an empty products list and without adding the `.catch` statement to the `getProducts` and seeing that I was missing the `skus` property, I couldn't figure it out. I think it should be clear from the documentation that `getProducts` returns a promise.