### PR TITLE
fix: Android 14 bug fixed (One of RECEIVER_EXPORTED or RECEIVER_NOT_E…

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@ RNIap_buildToolsVersion=30.0.2
 RNIap_ndkversion=21.4.7075529
 RNIap_playServicesVersion=18.1.0
 RNIap_amazonSdkVersion=3.0.4
-RNIap_playBillingSdkVersion=6.0.1
+RNIap_playBillingSdkVersion=6.1.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,9 +1,9 @@
-RNIap_kotlinVersion=1.7.21
+RNIap_kotlinVersion=1.8.0
 RNIap_minSdkVersion=21
-RNIap_targetSdkVersion=31
-RNIap_compileSdkVersion=31
-RNIap_buildToolsVersion=30.0.2
-RNIap_ndkversion=21.4.7075529
+RNIap_targetSdkVersion=33
+RNIap_compileSdkVersion=33
+RNIap_buildToolsVersion=33.0.0
+RNIap_ndkversion=23.1.7779620
 RNIap_playServicesVersion=18.1.0
 RNIap_amazonSdkVersion=3.0.4
 RNIap_playBillingSdkVersion=6.1.0


### PR DESCRIPTION
`com.android.billingclient:billing-ktx:6.0.1` makes apps using `react-native-iap`  crash when run on Android 14:

```
One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
```

`com.android.billingclient:billing-ktx:6.1.0` is safe for use.