### PR TITLE
fix: Use the correct product-updated event name

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -597,7 +597,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
             func addTransaction(transaction: Transaction) {
                 purchasedItems.append( transaction)
                 if alsoPublishToEventListener {
-                    self.sendEvent?("purchase-update", serialize(transaction))
+                    self.sendEvent?("purchase-updated", serialize(transaction))
                 }
             }
             func addError( error: Error, errorDict: [String: String]) {


### PR DESCRIPTION
During some testing of restoring purchases using the getAvailablePurchases method with the alsoPublishToEventListener argument set to true I noticed that the events were not being published correctly. I also noticed in the logs an error message saying that `purchase-update` was not a supported event.

I had a look at the code in RNIapIosSk2.swift and it appears that the event name should actually be `purchase-updated`.

I fixed this locally and the error no longer appears and the purchase is now being published to the event listener.