### PR TITLE
fix: Send purchase-updated instead of purchase-update.

### DIFF
--- a/.github/workflows/ci-example-ios.yml
+++ b/.github/workflows/ci-example-ios.yml
@@ -48,13 +48,11 @@ jobs:
           bundler-cache: true
           ruby-version: '2.7'
 
-      - name: GitHub Action for SwiftLint (Only files changed in the PR)
-        uses: norio-nomura/action-swiftlint@3.2.1
-        env:
-          DIFF_BASE: ${{ github.base_ref }}
+      - name: Install SwiftLint
+        run: brew install swiftlint
 
-      # - name: SwiftLint
-      #   run: swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml
+      - name: SwiftLint
+        run: swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml
 
       - name: Verify no files have changed after auto-fix
         run: git diff --exit-code HEAD '*.swift'

--- a/.github/workflows/ci-example-ios.yml
+++ b/.github/workflows/ci-example-ios.yml
@@ -48,8 +48,13 @@ jobs:
           bundler-cache: true
           ruby-version: '2.7'
 
-      - name: SwiftLint
-        run: swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml
+      - name: GitHub Action for SwiftLint (Only files changed in the PR)
+        uses: norio-nomura/action-swiftlint@3.2.1
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
+
+      # - name: SwiftLint
+      #   run: swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml
 
       - name: Verify no files have changed after auto-fix
         run: git diff --exit-code HEAD '*.swift'

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -597,7 +597,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
             func addTransaction(transaction: Transaction) {
                 purchasedItems.append( transaction)
                 if alsoPublishToEventListener {
-                    self.sendEvent?("purchase-update", serialize(transaction))
+                    self.sendEvent?("purchase-updated", serialize(transaction))
                 }
             }
             func addError( error: Error, errorDict: [String: String]) {


### PR DESCRIPTION
During some testing of restoring purchases using the getAvailablePurchases method with the alsoPublishToEventListener argument set to true I noticed that the events were not being published correctly. I also noticed in the logs an error message saying that purchase-update was not a supported event.

I had a look at the code in RNIapIosSk2.swift and it appears that the event name should actually be purchase-updated.

I fixed this locally and the error no longer appears and the purchase is now being published to the event listener.

Creating this as a draft PR as I am not too sure if there is anything else I need to do, this is my first contribution to the project.