### PR TITLE
fix: setting currentPurchaseError to undefined on useIAP hook unmount

### DIFF
--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect} from 'react';
 
 import {
   finishTransaction as iapFinishTransaction,
@@ -117,6 +117,12 @@ export const useIAP = (): IAP_STATUS => {
       setCurrentPurchaseError,
     ],
   );
+
+  useEffect(() => {
+    return () => {
+      setCurrentPurchaseError(undefined);
+    };
+  }, []);
 
   return {
     connected,

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -122,6 +122,7 @@ export const useIAP = (): IAP_STATUS => {
     return () => {
       setCurrentPurchaseError(undefined);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {


### PR DESCRIPTION
This PR sets currentPurchaseError to undefined when useIAP hook gets unmount. 

It's very important because when user first time goes to subscription screen and there is a useIAP hook and user try to purchase and fail then we get error. But user when again come backs to this screen then that currentPurchaseError value must be undefined but it's not undefined so this is a problem and I address this thing in this PR.

For Example: (Steps)
- "A" Screen has useIAP hook
- User comes to "A" Screen
- Try to purchase and Gets error
- Then user goes back and Come again to this screen
- Then user sees error because currentPurchaseError has still some value (So, we need to get this undefined each time when useIAP get unmount)

Conclusion: It makes sense that currentPurchaseError should be undefined on hook unmount.