### PR TITLE
fix: latest promise crash on StoreKit 1

### DIFF
--- a/ios/LatestPromiseKeeper.swift
+++ b/ios/LatestPromiseKeeper.swift
@@ -29,7 +29,6 @@ class LatestPromiseKeeper {
             ongoingRequest = nil
         }
 
-        // Clear the latestPromise after rejecting it
         clearLatestPromiseAndRequest()
     }
 

--- a/ios/LatestPromiseKeeper.swift
+++ b/ios/LatestPromiseKeeper.swift
@@ -30,7 +30,7 @@ class LatestPromiseKeeper {
         }
 
         // Clear the latestPromise after rejecting it
-        latestPromise.atomically { $0 = nil }
+        clearLatestPromiseAndRequest()
     }
 
     func resolveIfRequestMatches(matchingRequest: SKProductsRequest, items: [[String: Any?]], operation: (RCTPromiseResolveBlock, [[String: Any?]]) -> Void) {
@@ -43,5 +43,11 @@ class LatestPromiseKeeper {
                 operation(resolve, items)
             }
         }
+        clearLatestPromiseAndRequest()
+    }
+
+    private func clearLatestPromiseAndRequest() {
+        latestPromise.atomically { $0 = nil }
+        latestRequest.atomically { $0 = nil }
     }
 }


### PR DESCRIPTION
- Closes #2776 
- Fixes iOS bug on StoreKit 1 mode where making more than one request for products or subscriptions resulted in a crash
- Now properly clears request and promise references on promise resolution, rejection or cancel


## Evidence
### App not crashing in StoreKit 1 mode when making multiple requests:

https://github.com/dooboolab-community/react-native-iap/assets/3487334/fe610d66-e6e9-4489-9068-0169e1902c88


### A proper error is thrown in React's scope when parallel requests are made, with no application crash:

https://github.com/dooboolab-community/react-native-iap/assets/3487334/8e52287e-54b1-4cb5-b1c4-b807aceb686e

