### PR TITLE
fix: set connected false in endConnection

### DIFF
--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -52,6 +52,7 @@ export const useIAP = (): IAP_STATUS => {
     currentPurchase,
     currentPurchaseError,
     initConnectionError,
+    setConnected,
     setProducts,
     setSubscriptions,
     setAvailablePurchases,
@@ -119,7 +120,10 @@ export const useIAP = (): IAP_STATUS => {
   );
 
   useEffect(() => {
+    setConnected(true);
+
     return () => {
+      setConnected(false);
       setCurrentPurchaseError(undefined);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -28,6 +28,7 @@ type IAPContextType = {
   currentTransaction?: TransactionSk2;
   currentPurchaseError?: PurchaseError;
   initConnectionError?: Error;
+  setConnected: (connected: boolean) => void;
   setProducts: (products: Product[]) => void;
   setSubscriptions: (subscriptions: Subscription[]) => void;
   setPurchaseHistory: (purchaseHistory: Purchase[]) => void;
@@ -86,6 +87,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         currentTransaction,
         currentPurchaseError,
         initConnectionError,
+        setConnected,
         setProducts,
         setSubscriptions,
         setPurchaseHistory,
@@ -104,6 +106,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         currentTransaction,
         currentPurchaseError,
         initConnectionError,
+        setConnected,
         setProducts,
         setSubscriptions,
         setPurchaseHistory,

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -41,7 +41,6 @@ import {
   SubscriptionPlatform,
   SubscriptionPurchase,
 } from './types';
-import { useIAPContext } from './hooks/withIAPContext';
 
 export {IapAndroid, IapAmazon, IapIos, IapIosSk2, isIosStorekit2};
 
@@ -124,12 +123,8 @@ const App = () => {
 ```
  * @returns {Promise<void>}
  */
-export const endConnection = (): Promise<boolean> => {
-  const { setConnected } = useIAPContext();
-  
-  setConnected(false);
-  return getNativeModule().endConnection();
-}
+export const endConnection = (): Promise<boolean> =>
+  getNativeModule().endConnection();
 
 /**
  * Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache). Android only.

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -41,6 +41,7 @@ import {
   SubscriptionPlatform,
   SubscriptionPurchase,
 } from './types';
+import { useIAPContext } from './hooks/withIAPContext';
 
 export {IapAndroid, IapAmazon, IapIos, IapIosSk2, isIosStorekit2};
 
@@ -123,8 +124,12 @@ const App = () => {
 ```
  * @returns {Promise<void>}
  */
-export const endConnection = (): Promise<boolean> =>
-  getNativeModule().endConnection();
+export const endConnection = (): Promise<boolean> => {
+  const { setConnected } = useIAPContext();
+  
+  setConnected(false);
+  return getNativeModule().endConnection();
+}
 
 /**
  * Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache). Android only.


### PR DESCRIPTION
Hello.
I faced one problem using this.
Though a first purchase after the in-app connection is successful, the store purchase will be completed, but the `currentPurchase` status is not updating inside the library. I would have to repeat the purchase process by killing the app. 
In my opinion, the purchaseListener is connected by the change of the `connected` value inside `useEffect`, which changes from `false` to `true` only when the app is first connected and not after that, so I decided that I can't subscribe to the status of the current order.
So I added a code inside the `endConnection` method to make `connected` false.
This allows you to update every subscription correctly by changing `connected` to `true` when you access the order page and `false` when you access `endConnection`.
Both iOS and Android work as expected.

I think this issue is related to the issue below.
https://github.com/dooboolab-community/react-native-iap/issues/2700

I hope that this PR will be reflected so that it can help everyone.