### PR TITLE
doc(requestPurchase): fix the example in docstrings

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -544,15 +544,21 @@ requestPurchase(
 ## Usage
 
 ```tsx
-import React, {useCallback} from 'react';
+import React, { useState, useEffect } from 'react';
 import {Button} from 'react-native';
 import {requestPurchase, Product, Sku, getProducts} from 'react-native-iap';
 
 const App = () => {
-  const products = useCallback(
-    async () => getProducts({skus:['com.example.product']}),
-    [],
-  );
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+        const productList = await getProducts({skus:['com.example.product']});
+        setProducts(productList);
+    }
+
+    fetchProducts();
+  }, []);
 
   const handlePurchase = async (sku: Sku) => {
     await requestPurchase({sku});


### PR DESCRIPTION
`useCallback` returns a function (async in this case) that cannot be directly used in the render phase.
Therefore, a state should hold the result of the fetch.